### PR TITLE
Handle has_many through has_many with nonstandard table names and foreign keys

### DIFF
--- a/activerecord/test/cases/associations/has_many_through_associations_test.rb
+++ b/activerecord/test/cases/associations/has_many_through_associations_test.rb
@@ -36,12 +36,16 @@ require "models/family_tree"
 require "models/section"
 require "models/seminar"
 require "models/session"
+require "models/artist"
+require "models/album"
+require "models/song"
 
 class HasManyThroughAssociationsTest < ActiveRecord::TestCase
   fixtures :posts, :readers, :people, :comments, :authors, :categories, :taggings, :tags,
            :owners, :pets, :toys, :jobs, :references, :companies, :members, :author_addresses,
            :subscribers, :books, :subscriptions, :developers, :categorizations, :essays,
-           :categories_posts, :clubs, :memberships, :organizations, :author_favorites
+           :categories_posts, :clubs, :memberships, :organizations, :author_favorites, :artists,
+           :albums, :songs
 
   # Dummies to force column loads so query counts are clean.
   def setup
@@ -913,6 +917,10 @@ class HasManyThroughAssociationsTest < ActiveRecord::TestCase
 
   def test_has_many_association_through_a_has_many_association_with_nonstandard_primary_keys
     assert_equal 2, owners(:blackbeard).toys.count
+  end
+
+  def test_has_many_association_through_a_has_many_association_with_a_nonstandard_table_name_and_foreign_key
+    assert_equal 3, artists(:the_beach_boys).songs.count
   end
 
   def test_find_on_has_many_association_collection_with_include_and_conditions

--- a/activerecord/test/fixtures/albums.yml
+++ b/activerecord/test/fixtures/albums.yml
@@ -1,0 +1,7 @@
+surfin_safari:
+  id: 1
+  artist_id: 1
+
+pet_sounds:
+  id: 2
+  artist_id: 1

--- a/activerecord/test/fixtures/artists.yml
+++ b/activerecord/test/fixtures/artists.yml
@@ -1,0 +1,2 @@
+the_beach_boys:
+  id: 1

--- a/activerecord/test/fixtures/songs.yml
+++ b/activerecord/test/fixtures/songs.yml
@@ -1,0 +1,11 @@
+surfin:
+  id: 1
+  album: 1
+
+sloop_john_b:
+  id: 2
+  album: 2
+
+caroline_no:
+  id: 3
+  album: 2

--- a/activerecord/test/models/album.rb
+++ b/activerecord/test/models/album.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class Album < ActiveRecord::Base
+  has_many :songs, foreign_key: 'album'
+  belongs_to :artist
+
+  self.table_name = 'album'
+end

--- a/activerecord/test/models/artist.rb
+++ b/activerecord/test/models/artist.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Artist < ActiveRecord::Base
+  has_many :albums
+  has_many :songs, through: :albums
+end

--- a/activerecord/test/models/song.rb
+++ b/activerecord/test/models/song.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Song < ActiveRecord::Base
+  belongs_to :album, foreign_key: 'album'
+end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -41,6 +41,10 @@ ActiveRecord::Schema.define do
     t.timestamp :manufactured_at, default: -> { "CURRENT_TIMESTAMP" }
   end
 
+  create_table :album, force: true do |t|
+    t.references :artist
+  end
+
   create_table :articles, force: true do |t|
   end
 
@@ -52,6 +56,9 @@ ActiveRecord::Schema.define do
   create_table :articles_tags, force: true do |t|
     t.references :article
     t.references :tag
+  end
+
+  create_table :artists, force: true do |t|
   end
 
   create_table :audit_logs, force: true do |t|
@@ -1003,6 +1010,10 @@ ActiveRecord::Schema.define do
   create_table :shop_accounts, force: true do |t|
     t.references :customer
     t.references :customer_carrier
+  end
+
+  create_table :songs, force: true do |t|
+    t.integer :album
   end
 
   create_table :speedometers, force: true, id: false do |t|


### PR DESCRIPTION


### Summary

<!-- Provide a general description of the code changes in your pull
request... were there any bugs you had fixed? If so, mention them. If
these bugs have open GitHub issues, be sure to tag them here as well,
to keep the conversation linked together. -->

This (will) fix a bug described in https://github.com/rails/rails/issues/43653 in which incorrect queries are generated for has_many associations through other has_many associations with both a nonstandard table name and a nonstandard foreign key.


### Other Information

<!-- If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](https://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails! -->

<!--
Note: Please avoid making *Draft* pull requests, as they still send
notifications to everyone watching the Rails repo.
Create a pull request when it is ready for review and feedback
from the Rails team :).
-->
